### PR TITLE
handle prefix for ansible lint

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -15,7 +15,7 @@ DOCSIBLE_END_TAG = "<!-- DOCSIBLE END -->"
 timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
 
 def get_version():
-    return "0.7.0"
+    return "0.7.1"
 
 def manage_docsible_file_keys(docsible_path):
     default_data = {

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -124,7 +124,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in defaultfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](defaults/{{ defaultfile.file }}#L{{details.line}})   | {{ var_type }}   | `{{ details.value | replace('|', '\|') }}`  | {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '\|') }} |{% endif %}
+| [{{ key }}](defaults/{{ defaultfile.file }}#L{{details.line}})   | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}`  | {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 
@@ -167,7 +167,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in varsfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](vars/{{ varsfile.file }}#L{{details.line}})    | {{ var_type }}   | `{{ details.value | replace('|', '\|') }}`  |{% if ns.details_required %} {{ details.required }} |{% endif %}{% if ns.details_title %} {{ details.title | replace('|', '\|') }} |{% endif %}
+| [{{ key }}](vars/{{ varsfile.file }}#L{{details.line}})    | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}`  |{% if ns.details_required %} {{ details.required }} |{% endif %}{% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 
@@ -202,7 +202,7 @@ Description: Not available.
 | Name | Module | Has Conditions |{% if ns.comments_required %} Comments |{% endif %}
 | ---- | ------ | --------- |{% if ns.comments_required %}  -------- |{% endif %}
 {%- for task in taskfile.tasks %}
-| {{ task.name }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |{% if ns.comments_required %} {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |{% endif %}
+| {{ task.name.replace("|", "¦") }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |{% if ns.comments_required %} {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |{% endif %}
 {%- endfor %}
 {% endfor %}
 

--- a/docsible/utils/mermaid.py
+++ b/docsible/utils/mermaid.py
@@ -2,7 +2,7 @@ import re
 
 
 def sanitize_for_mermaid_id(text):
-    text = text.replace(r"\|", "_")
+    text = text.replace("|", "_")
     # Allowing a-zA-Z0-9 as well as French accents
     return re.sub(r'[^a-zA-Z0-9À-ÿ]', '_', text)
 
@@ -93,7 +93,7 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
                     check_style_included_tasks = task_module_include_tasks
                 sanitized_include_tasks_name = sanitize_for_mermaid_id(f"{check_style_included_tasks}{i}")
                 sanitized_include_tasks_title = sanitize_for_mermaid_id(f"{check_style_included_tasks}")
-                mermaid_data += f'\n  {last_node}-->|Include task| {sanitized_include_tasks_name}[\{sanitized_task_title}<br>include_task: {sanitized_include_tasks_title}\]:::includeTasks'
+                mermaid_data += f'\n  {last_node}-->|Include task| {sanitized_include_tasks_name}[{{{{{sanitized_task_title}}}}}<br>include_task: {{{{{sanitized_include_tasks_title}}}}}]:::includeTasks'
                 last_node = sanitized_include_tasks_name
                 if when_condition:
                     mermaid_data += f'\n  {sanitized_include_tasks_name}---|When: {sanitized_when_condition}| {sanitized_include_tasks_name}'
@@ -115,7 +115,7 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
             elif task_module_import_playbook:
                 sanitized_module_import_playbook_name = sanitize_for_mermaid_id(f"{task_module_import_playbook}{i}")
                 sanitized_module_import_playbook_title = sanitize_for_mermaid_id(f"{task_module_import_playbook}")
-                mermaid_data += f'\n  {last_node}-->|Import playbook| {sanitized_module_import_playbook_name}[/{sanitized_task_title}<br>import_playbook: {sanitized_module_import_playbook_title}\]:::importPlaybook'
+                mermaid_data += f'\n  {last_node}-->|Import playbook| {sanitized_module_import_playbook_name}[/{{{{{sanitized_task_title}}}}}<br>import_playbook: {{{{{sanitized_module_import_playbook_title}}}}}]:::importPlaybook'
                 last_node = sanitized_module_import_playbook_name
                 if when_condition:
                     mermaid_data += f'\n  {sanitized_module_import_playbook_name}---|When: {sanitized_when_condition}| {sanitized_module_import_playbook_name}'

--- a/docsible/utils/special_tasks_keys.py
+++ b/docsible/utils/special_tasks_keys.py
@@ -3,7 +3,7 @@
 def escape_pipes(text):
     """Function to escape pipes in string or list"""
     if isinstance(text, str):
-        return text.replace("|", r"\|")
+        return text.replace("|", r"¦")
     if isinstance(text, list):
         return [escape_pipes(item) for item in text]
     return None

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -150,31 +150,26 @@ def get_task_comments(filepath):
     for line in lines:
         stripped_line = line.strip()
 
-        # Check if the line is a comment and accumulate it
+        # Accumulate comments found directly above each task
         if stripped_line.startswith("#"):
             if comment_line:
-                comment_line += " "  # Add space between lines
+                comment_line += " "
             comment_line += stripped_line.split("#", 1)[1].strip()
 
-        # If the line starts with "- name:", it's a new task
+        # If a new task starts with "- name:", capture the accumulated comments and task name
         elif stripped_line.startswith("- name:"):
-            task_name = stripped_line.replace("- name:", "").split("#")[0].strip()
-            if comment_line:
-                task_comments.append({
-                    "task_name": task_name,
-                    "task_comments": comment_line
-                })
-                comment_line = ""  # Reset the comment_line for the next task
-            else:
-                task_comments.append({
-                    "task_name": task_name,
-                    "task_comments": ""
-                })
+            task_name = stripped_line.replace("- name:", "").split("#")[0].strip().replace("|", "¦")
+            task_comments.append({
+                "task_name": task_name,
+                "task_comments": comment_line.strip()  # Trim excess whitespace
+            })
+            comment_line = ""  # Reset for the next task
 
-        # If a new task starts or another structure (like block) begins, reset comments
-        else:
-            if stripped_line.startswith("-") and not stripped_line.startswith("- name:"):
-                if comment_line:
-                    task_comments[-1]["task_comments"] += " " + comment_line
-                comment_line = ""
+        # Reset comments if a new list item or block begins, without a "- name:"
+        elif stripped_line.startswith("-") and not stripped_line.startswith("- name:"):
+            if comment_line:
+                # Append to the last task's comments to avoid losing data
+                task_comments[-1]["task_comments"] += " " + comment_line
+            comment_line = ""
+
     return task_comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.7.0"
+version = "0.7.1"
 description = "Document generator for ansible role/collection"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.7.0',
+    version='0.7.1',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
Replaced `|` with `¦` on all titles tasks