### PR TITLE
Nice handle when: conditions for mermaid v11.3.0 on github

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -15,7 +15,7 @@ DOCSIBLE_END_TAG = "<!-- DOCSIBLE END -->"
 timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
 
 def get_version():
-    return "0.7.1"
+    return "0.7.2"
 
 def manage_docsible_file_keys(docsible_path):
     default_data = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.7.1"
+version = "0.7.2"
 description = "Document generator for ansible role/collection"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.7.1',
+    version='0.7.2',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
### Changes

1. **Refactor Conditional Rendering (`when` conditions):**
   - Updated the handling of `when` conditions to display them as bold text (`**`) and included them as `<br>When: ...` within task titles, enhancing readability and compatibility.
   - Removed redundant condition nodes previously added separately. The condition text is now directly embedded within node labels, ensuring GitHub’s Mermaid renderer displays the conditions correctly.

2. **Node Structure and Title Adjustments:**
   - Simplified how nodes are constructed for various tasks such as `include_task`, `import_task`, `include_role`, and `import_role` to prevent duplicate or conflicting nodes in the generated Mermaid diagrams.
   - Improved labeling within nodes, using cleaner syntax to ensure that the labels are more readable and consistently formatted across different Mermaid versions.

3. **CSS Class Definitions Cleanup:**
   - Consolidated and refined the CSS class definitions used in Mermaid diagrams, specifically for blocks like `includeTasks`, `rescue`, and `importTasks`. These changes standardize the appearance and ensure compatibility with GitHub’s Mermaid styling.