### PR TITLE
Feature/fqdn links

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -4,18 +4,21 @@ import yaml
 import click
 from shutil import copyfile
 from datetime import datetime
-from jinja2 import Environment, BaseLoader, FileSystemLoader 
+from jinja2 import Environment, BaseLoader, FileSystemLoader
 from docsible.markdown_template import static_template, collection_template
 from docsible.utils.mermaid import generate_mermaid_playbook, generate_mermaid_role_tasks_per_file
 from docsible.utils.yaml import load_yaml_generic, load_yaml_files_from_dir_custom, get_task_comments
 from docsible.utils.special_tasks_keys import process_special_task_keys
+from docsible.utils.git import get_repo_info
 
 DOCSIBLE_START_TAG = "<!-- DOCSIBLE START -->"
 DOCSIBLE_END_TAG = "<!-- DOCSIBLE END -->"
 timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
 
+
 def get_version():
     return "0.7.12"
+
 
 def manage_docsible_file_keys(docsible_path):
     default_data = {
@@ -36,7 +39,7 @@ def manage_docsible_file_keys(docsible_path):
     if os.path.exists(docsible_path):
         with open(docsible_path, 'r') as f:
             existing_data = yaml.safe_load(f) or {}
-        
+
         updated_data = {**default_data, **existing_data}
         if updated_data != existing_data:
             # Update dt_update field if docsible keys added
@@ -49,8 +52,10 @@ def manage_docsible_file_keys(docsible_path):
             yaml.dump(default_data, f, default_flow_style=False)
         print(f"Initialized {docsible_path} with default keys.")
 
+
 def manage_docsible_tags(content):
     return f"{DOCSIBLE_START_TAG}\n{content}\n{DOCSIBLE_END_TAG}"
+
 
 def replace_between_tags(existing_content, new_content):
     start_index = existing_content.find(DOCSIBLE_START_TAG)
@@ -62,6 +67,7 @@ def replace_between_tags(existing_content, new_content):
         return f"{before}\n{new_content}\n{after}".strip()
     else:
         return existing_content + '\n' + new_content.strip()
+
 
 def render_readme_template(collection_metadata, md_collection_template, roles_info, output_path, append):
     """
@@ -82,41 +88,45 @@ def render_readme_template(collection_metadata, md_collection_template, roles_in
     }
     new_content = template.render(data)
     new_content = manage_docsible_tags(new_content)
-    
+
     if os.path.exists(output_path):
         with open(output_path, 'r', encoding='utf-8') as f:
             existing_readme = f.read()
         if append:
             if DOCSIBLE_START_TAG in existing_readme and DOCSIBLE_END_TAG in existing_readme:
-                final_content = replace_between_tags(existing_readme, new_content)
+                final_content = replace_between_tags(
+                    existing_readme, new_content)
             else:
                 final_content = f"{existing_readme}\n{new_content}"
         else:
             final_content = new_content
     else:
         final_content = new_content
-    
+
     with open(output_path, 'w', encoding='utf-8') as readme_file:
         readme_file.write(final_content)
     print(f"Collection README.md written at: {output_path}")
 
-def document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments, md_collection_template, md_role_template, append, output):
+
+def document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments, md_collection_template, md_role_template, append, output, repository_url, repo_type, repo_branch):
     """
     Document all roles in a collection, extracting metadata from galaxy.yml or galaxy.yaml.
     """
     for root, dirs, files in os.walk(collection_path):
-        galaxy_file = next((f for f in files if f in ['galaxy.yml', 'galaxy.yaml']), None)
+        galaxy_file = next(
+            (f for f in files if f in ['galaxy.yml', 'galaxy.yaml']), None)
         if galaxy_file:
             galaxy_path = os.path.join(root, galaxy_file)
             with open(galaxy_path, 'r') as f:
                 collection_metadata = yaml.safe_load(f)
                 if output == "README.md":
-                    readme_path = os.path.join(root, collection_metadata.get('readme', output))
+                    readme_path = os.path.join(
+                        root, collection_metadata.get('readme', output))
                 else:
                     readme_path = os.path.join(root, output)
 
             if os.path.exists(readme_path) and not no_backup:
-                backup_path = f"{ readme_path[:readme_path.lower().rfind('.md')] }_backup_{timestamp}.md"
+                backup_path = f"{readme_path[:readme_path.lower().rfind('.md')]}_backup_{timestamp}.md"
                 copyfile(readme_path, backup_path)
                 print(f"Backup of existing {output} created at: {backup_path}")
 
@@ -128,7 +138,8 @@ def document_collection_roles(collection_path, playbook, graph, no_backup, no_do
                     if os.path.isdir(role_path):
                         if playbook:
                             playbook_content = None
-                            role_playbook_path = os.path.join(role_path, playbook)
+                            role_playbook_path = os.path.join(
+                                role_path, playbook)
                             try:
                                 with open(role_playbook_path, 'r') as f:
                                     playbook_content = f.read()
@@ -136,10 +147,13 @@ def document_collection_roles(collection_path, playbook, graph, no_backup, no_do
                                 print(f'{role} not found:', role_playbook_path)
                             except Exception as e:
                                 print(f'{playbook} import for {role} error:', e)
-                        role_info = document_role(role_path, playbook_content, graph, no_backup, no_docsible, comments, md_role_template, belongs_to_collection=collection_metadata, append=append, output=output)
+                        role_info = document_role(role_path, playbook_content, graph, no_backup, no_docsible, comments, md_role_template,
+                                                  belongs_to_collection=collection_metadata, append=append, output=output, repository_url=None, repo_type=repo_type, repo_branch=repo_branch)
                         roles_info.append(role_info)
 
-            render_readme_template(collection_metadata, md_collection_template, roles_info, readme_path, append)
+            render_readme_template(
+                collection_metadata, md_collection_template, roles_info, readme_path, append)
+
 
 @click.command()
 @click.option('--role', '-r', default=None, help='Path to the Ansible role directory.')
@@ -153,15 +167,18 @@ def document_collection_roles(collection_path, playbook, graph, no_backup, no_do
 @click.option('--md-role-template', '-rt', '--md-template', '-tpl', default=None, help='Path to the role markdown template file.')
 @click.option('--append', '-a', is_flag=True, help='Append to the existing README.md instead of replacing it.')
 @click.option('--output', '-o', default='README.md', help='Output readme file name.')
+@click.option('--repository-url', '-ru', default=None, help='Repository base URL (used for standalone roles)')
+@click.option('--repo-type', '-rt', default=None, help='Repository type: github, gitlab, gitea, etc.')
+@click.option('--repo-branch', '-rb', default='main', help='Repository branch name (e.g., main or master)')
 @click.version_option(version=get_version(), help=f"Show the module version. Actual is {get_version()}")
-
-def doc_the_role(role, collection, playbook, graph, no_backup, no_docsible, comments, md_collection_template, md_role_template, append, output):
+def doc_the_role(role, collection, playbook, graph, no_backup, no_docsible, comments, md_collection_template, md_role_template, append, output, repository_url, repo_type, repo_branch):
     if collection:
         collection_path = os.path.abspath(collection)
         if not os.path.exists(collection_path) or not os.path.isdir(collection_path):
             print(f"Folder {collection_path} does not exist.")
             return
-        document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments, md_collection_template, md_role_template, append, output)
+        document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments,
+                                  md_collection_template, md_role_template, append, output, repository_url, repo_type, repo_branch)
     elif role:
         role_path = os.path.abspath(role)
         if not os.path.exists(role_path) or not os.path.isdir(role_path):
@@ -180,11 +197,13 @@ def doc_the_role(role, collection, playbook, graph, no_backup, no_docsible, comm
                 print('playbook not found:', playbook)
             except Exception as e:
                 print('playbook import error:', e)
-        document_role(role_path, playbook_content, graph, no_backup, no_docsible, comments, md_role_template, belongs_to_collection=False, append=append, output=output)
+        document_role(role_path, playbook_content, graph, no_backup, no_docsible, comments, md_role_template, belongs_to_collection=False,
+                      append=append, output=output, repository_url=repository_url, repo_type=repo_type, repo_branch=repo_branch)
     else:
         print("Please specify either a role or a collection path.")
 
-def document_role(role_path, playbook_content, generate_graph, no_backup, no_docsible, comments, md_role_template, belongs_to_collection, append, output):
+
+def document_role(role_path, playbook_content, generate_graph, no_backup, no_docsible, comments, md_role_template, belongs_to_collection, append, output, repository_url, repo_type, repo_branch):
     role_name = os.path.basename(role_path)
     readme_path = os.path.join(role_path, output)
     meta_path = os.path.join(role_path, "meta", "main.yml")
@@ -199,7 +218,8 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
         meta_path = os.path.join(role_path, "meta", "main.yaml")
 
     if not os.path.exists(argument_specs_path):
-        argument_specs_path = os.path.join(role_path, "meta", "argument_specs.yaml")
+        argument_specs_path = os.path.join(
+            role_path, "meta", "argument_specs.yaml")
 
     if os.path.exists(argument_specs_path):
         argument_specs = load_yaml_generic(argument_specs_path)
@@ -211,6 +231,17 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
     vars_data = load_yaml_files_from_dir_custom(
         os.path.join(role_path, "vars")) or []
 
+    try:
+        git_info = get_repo_info(role_path) or {}
+    except Exception as e:
+        print(f"[WARN] Could not get Git info: {e}")
+        git_info = {}
+
+    repository_url = repository_url or (
+        git_info.get("repository") if git_info else None)
+    repo_branch = repo_branch or (
+        git_info.get("branch") if git_info else "main")
+
     role_info = {
         "name": role_name,
         "defaults": defaults_data,
@@ -218,9 +249,12 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
         "tasks": [],
         "meta": load_yaml_generic(meta_path) or {},
         "playbook": {"content": playbook_content, "graph":
-                        generate_mermaid_playbook(yaml.safe_load(playbook_content)) if generate_graph and playbook_content else None},
+                     generate_mermaid_playbook(yaml.safe_load(playbook_content)) if generate_graph and playbook_content else None},
         "docsible": load_yaml_generic(docsible_path) if not no_docsible else None,
         "belongs_to_collection": belongs_to_collection,
+        "repository": repository_url,
+        "repository_type": repo_type,
+        "repository_branch": repo_branch,
         "argument_specs": argument_specs
     }
 
@@ -235,18 +269,23 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
                     tasks_data = load_yaml_generic(file_path)
                     if tasks_data:
                         relative_path = os.path.relpath(file_path, tasks_dir)
-                        task_info = {'file': relative_path, 'tasks': [], 'mermaid': [], "comments": []}
+                        task_info = {'file': relative_path,
+                                     'tasks': [], 'mermaid': [], "comments": []}
                         if comments:
-                            task_info['comments'] = get_task_comments(file_path)
+                            task_info['comments'] = get_task_comments(
+                                file_path)
                         if not isinstance(tasks_data, list):
-                            print(f"Unexpected data type for tasks in {task_file}. Skipping.")
+                            print(
+                                f"Unexpected data type for tasks in {task_file}. Skipping.")
                             continue
                         for task in tasks_data:
                             if not isinstance(task, dict):
-                                print(f"Skipping unexpected data in {task_file}: {task}")
+                                print(
+                                    f"Skipping unexpected data in {task_file}: {task}")
                                 continue
                             if task and len(task.keys()) > 0:
-                                processed_tasks = process_special_task_keys(task)
+                                processed_tasks = process_special_task_keys(
+                                    task)
                                 task_info['tasks'].extend(processed_tasks)
                                 task_info['mermaid'].extend([task])
 
@@ -254,7 +293,8 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
 
     if os.path.exists(readme_path):
         if not no_backup:
-            backup_readme_path = os.path.join(role_path, f"{ output[:output.lower().rfind('.md')] }_backup_{timestamp}.md")
+            backup_readme_path = os.path.join(
+                role_path, f"{output[:output.lower().rfind('.md')]}_backup_{timestamp}.md")
             copyfile(readme_path, backup_readme_path)
             print(f'Readme file backed up as: {backup_readme_path}')
         if not append:
@@ -262,8 +302,9 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
 
     mermaid_code_per_file = {}
     if generate_graph:
-        mermaid_code_per_file = generate_mermaid_role_tasks_per_file(role_info["tasks"])
-    
+        mermaid_code_per_file = generate_mermaid_role_tasks_per_file(
+            role_info["tasks"])
+
     # Render the static template
     if md_role_template:
         template_dir = os.path.dirname(md_role_template)
@@ -273,22 +314,24 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
     else:
         env = Environment(loader=BaseLoader)
         template = env.from_string(static_template)
-    new_content = template.render(role=role_info, mermaid_code_per_file=mermaid_code_per_file)
+    new_content = template.render(
+        role=role_info, mermaid_code_per_file=mermaid_code_per_file)
     new_content = manage_docsible_tags(new_content)
-    
+
     if os.path.exists(readme_path):
         with open(readme_path, 'r', encoding='utf-8') as f:
             existing_readme = f.read()
         if append:
             if DOCSIBLE_START_TAG in existing_readme and DOCSIBLE_END_TAG in existing_readme:
-                final_content = replace_between_tags(existing_readme, new_content)
+                final_content = replace_between_tags(
+                    existing_readme, new_content)
             else:
                 final_content = f"{existing_readme}\n{new_content}"
         else:
             final_content = new_content
     else:
         final_content = new_content
-    
+
     with open(readme_path, "w", encoding='utf-8') as f:
         f.write(final_content)
 

--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -17,7 +17,7 @@ timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
 
 
 def get_version():
-    return "0.7.12"
+    return "0.7.13"
 
 
 def manage_docsible_file_keys(docsible_path):

--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -107,6 +107,23 @@ Description: Not available.
 {% else %}
 {% endif %}
 
+{% macro render_repo_link(repo, role_name, file_path, line, repo_type='default', branch='main') -%}
+  {%- if repo and role_name and file_path and line is not none -%}
+    {%- set full_path = 'roles/' ~ role_name ~ '/' ~ file_path -%}
+    {%- if repo_type == 'github' -%}
+      {{ repo }}/blob/{{ branch }}/{{ full_path }}#L{{ line }}
+    {%- elif repo_type == 'gitlab' -%}
+      {{ repo }}/-/blob/{{ branch }}/{{ full_path }}#L{{ line }}
+    {%- elif repo_type == 'gitea' -%}
+      {{ repo }}/src/branch/{{ branch }}/{{ full_path }}#L{{ line }}
+    {%- else -%}
+      {{ repo }}/{{ full_path }}#L{{ line }}
+    {%- endif %}
+  {%- else -%}
+    {{ file_path }}#L{{ line }}
+  {%- endif %}
+{%- endmacro %}
+
 {% if role.defaults|length > 0 -%}
 ### Defaults
 
@@ -125,7 +142,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_choices %}-------------|{% endif %}{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in defaultfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](defaults/{{ defaultfile.file }}#L{{details.line}})   | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}` | {% if ns.details_choices %} {{ details.choices | replace('|', '¦') }}  |{% endif %}  {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
+| [{{ key }}]({{ render_repo_link(role.repository, role.name, 'defaults/' ~ defaultfile.file, details.line, role.repository_type, role.repository_branch) }})   | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}` | {% if ns.details_choices %} {{ details.choices | replace('|', '¦') }}  |{% endif %}  {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 
@@ -169,7 +186,7 @@ Description: Not available.
 |--------------|--------------|-------------|{% if ns.details_choices %}-------------|{% endif %}{% if ns.details_required %}-------------|{% endif %}{% if ns.details_title %}-------------|{% endif %}
 {%- for key, details in varsfile.data.items() %}
 {%- set var_type = details.value.__class__.__name__ %}
-| [{{ key }}](vars/{{ varsfile.file }}#L{{details.line}})   | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}` | {% if ns.details_choices %} {{ details.choices | replace('|', '¦') }}  |{% endif %}  {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
+| [{{ key }}]({{ render_repo_link(role.repository, role.name, 'vars/' ~ varsfile.file, details.line, role.repository_type, role.repository_branch) }})   | {{ var_type }}   | `{{ details.value | replace('|', '¦') }}` | {% if ns.details_choices %} {{ details.choices | replace('|', '¦') }}  |{% endif %}  {% if ns.details_required %} {{ details.required }}  |{% endif %} {% if ns.details_title %} {{ details.title | replace('|', '¦') }} |{% endif %}
 {%- endfor %}
 {%- endfor %}
 

--- a/docsible/utils/git.py
+++ b/docsible/utils/git.py
@@ -1,0 +1,36 @@
+import subprocess
+
+
+def get_repo_info(path):
+    try:
+        # Check if inside a git repo
+        result = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, check=True
+        )
+        if result.stdout.strip() != 'true':
+            return None
+
+        # Get remote URL
+        remote_url = subprocess.run(
+            ["git", "-C", path, "config", "--get", "remote.origin.url"],
+            capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        # Clean URL
+        if remote_url.endswith(".git"):
+            remote_url = remote_url[:-4]
+        remote_url = remote_url.rstrip("/")
+
+        # Get current branch
+        branch = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+        return {
+            "repository": remote_url,
+            "branch": branch
+        }
+    except subprocess.CalledProcessError:
+        return None

--- a/docsible/utils/mermaid.py
+++ b/docsible/utils/mermaid.py
@@ -42,12 +42,18 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
     for i, task in enumerate(tasks):
         has_rescue = False
         task_name = task.get("name", f"Unnamed_task_{i}")
-        task_module_include_tasks = task.get("ansible.builtin.include_tasks") or task.get("include_tasks", False)
-        task_module_import_tasks = task.get("ansible.builtin.import_tasks") or task.get("import_tasks", False)
-        task_module_import_playbook = task.get("ansible.builtin.import_playbook") or task.get("import_playbook", False)
-        task_module_include_role = task.get("ansible.builtin.include_role") or task.get("include_role", False)
-        task_module_import_role = task.get("ansible.builtin.import_role") or task.get("import_role", False)
-        task_module_include_vars = task.get("ansible.builtin.include_vars") or task.get("include_vars", False)
+        task_module_include_tasks = task.get(
+            "ansible.builtin.include_tasks") or task.get("include_tasks", False)
+        task_module_import_tasks = task.get(
+            "ansible.builtin.import_tasks") or task.get("import_tasks", False)
+        task_module_import_playbook = task.get(
+            "ansible.builtin.import_playbook") or task.get("import_playbook", False)
+        task_module_include_role = task.get(
+            "ansible.builtin.include_role") or task.get("include_role", False)
+        task_module_import_role = task.get(
+            "ansible.builtin.import_role") or task.get("import_role", False)
+        task_module_include_vars = task.get(
+            "ansible.builtin.include_vars") or task.get("include_vars", False)
         when_condition = task.get("when", False)
         block = task.get("block", False)
         rescue = task.get("rescue", False)
@@ -67,7 +73,8 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
                 block, block_start_node, mermaid_data, block_start_node, level + 1, in_rescue_block=False)
             if rescue:
                 has_rescue = True
-                rescue_start_node = sanitized_task_name + f'_rescue_start_{level}'
+                rescue_start_node = sanitized_task_name + \
+                    f'_rescue_start_{level}'
                 mermaid_data += f'\n  {last_node}-->|Rescue Start| {rescue_start_node}[{sanitized_task_title}]:::rescue'
                 last_node, mermaid_data = process_tasks(
                     rescue, rescue_start_node, mermaid_data, block_start_node, level + 1, in_rescue_block=True)
@@ -84,61 +91,79 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
 
             if task_module_include_tasks:
                 if isinstance(task_module_include_tasks, dict):
-                    check_style_included_tasks = task_module_include_tasks.get('file', task_module_include_tasks)
+                    check_style_included_tasks = task_module_include_tasks.get(
+                        'file', task_module_include_tasks)
                 else:
                     check_style_included_tasks = task_module_include_tasks
-                sanitized_include_tasks_name = sanitize_for_mermaid_id(f"{check_style_included_tasks}{i}")
-                sanitized_include_tasks_title = sanitize_for_title(f"{check_style_included_tasks}")
+                sanitized_include_tasks_name = sanitize_for_mermaid_id(
+                    f"{check_style_included_tasks}{i}")
+                sanitized_include_tasks_title = sanitize_for_title(
+                    f"{check_style_included_tasks}")
                 mermaid_data += f'\n  {last_node}-->|Include task| {sanitized_include_tasks_name}[{sanitized_task_title}<br>include_task: {sanitized_include_tasks_title}]:::includeTasks'
                 last_node = sanitized_include_tasks_name
 
             elif task_module_import_tasks:
                 if isinstance(task_module_import_tasks, dict):
-                    check_style_imported_tasks = task_module_import_tasks.get('file', task_module_import_tasks)
+                    check_style_imported_tasks = task_module_import_tasks.get(
+                        'file', task_module_import_tasks)
                 else:
                     check_style_imported_tasks = task_module_import_tasks
-                sanitized_imported_tasks_name = sanitize_for_mermaid_id(f"{check_style_imported_tasks}{i}")
-                sanitized_imported_tasks_title = sanitize_for_title(f"{check_style_imported_tasks}")
+                sanitized_imported_tasks_name = sanitize_for_mermaid_id(
+                    f"{check_style_imported_tasks}{i}")
+                sanitized_imported_tasks_title = sanitize_for_title(
+                    f"{check_style_imported_tasks}")
                 mermaid_data += f'\n  {last_node}-->|Import task| {sanitized_imported_tasks_name}[/{sanitized_task_title}<br>import_task: {sanitized_imported_tasks_title}/]:::importTasks'
                 last_node = sanitized_imported_tasks_name
 
             elif task_module_import_playbook:
                 if isinstance(task_module_import_playbook, dict):
-                    check_style_import_playbook = task_module_import_playbook.get('file', task_module_import_playbook)
+                    check_style_import_playbook = task_module_import_playbook.get(
+                        'file', task_module_import_playbook)
                 else:
                     check_style_import_playbook = task_module_import_playbook
-                sanitized_import_playbook_name = sanitize_for_mermaid_id(f"{check_style_import_playbook}{i}")
-                sanitized_import_playbook_title = sanitize_for_title(f"{check_style_import_playbook}")
+                sanitized_import_playbook_name = sanitize_for_mermaid_id(
+                    f"{check_style_import_playbook}{i}")
+                sanitized_import_playbook_title = sanitize_for_title(
+                    f"{check_style_import_playbook}")
                 mermaid_data += f'\n  {last_node}-->|Import playbook| {sanitized_import_playbook_name}[/{sanitized_task_title}<br>import_playbook: {sanitized_import_playbook_title}/]:::importPlaybook'
                 last_node = sanitized_import_playbook_name
 
             elif task_module_include_role:
                 if isinstance(task_module_include_role, dict):
-                    check_style_include_role = task_module_include_role.get('name', task_module_include_role)
+                    check_style_include_role = task_module_include_role.get(
+                        'name', task_module_include_role)
                 else:
                     check_style_include_role = task_module_include_role
-                sanitized_include_role_name = sanitize_for_mermaid_id(f"{check_style_include_role}{i}")
-                sanitized_include_role_title = sanitize_for_title(check_style_include_role)
+                sanitized_include_role_name = sanitize_for_mermaid_id(
+                    f"{check_style_include_role}{i}")
+                sanitized_include_role_title = sanitize_for_title(
+                    check_style_include_role)
                 mermaid_data += f'\n  {last_node}-->|Include role| {sanitized_include_role_name}({sanitized_task_title}<br>include_role: {sanitized_include_role_title}):::includeRole'
                 last_node = sanitized_include_role_name
 
             elif task_module_import_role:
                 if isinstance(task_module_import_role, dict):
-                    check_style_import_role = task_module_import_role.get('name', task_module_import_role)
+                    check_style_import_role = task_module_import_role.get(
+                        'name', task_module_import_role)
                 else:
                     check_style_import_role = task_module_import_role
-                sanitized_import_role_name = sanitize_for_mermaid_id(f"{check_style_import_role}{i}")
-                sanitized_import_role_title = sanitize_for_title(check_style_import_role)
+                sanitized_import_role_name = sanitize_for_mermaid_id(
+                    f"{check_style_import_role}{i}")
+                sanitized_import_role_title = sanitize_for_title(
+                    check_style_import_role)
                 mermaid_data += f'\n  {last_node}-->|Import role| {sanitized_import_role_name}([{sanitized_task_title}<br>import_role: {sanitized_import_role_title}]):::importRole'
                 last_node = sanitized_import_role_name
 
             elif task_module_include_vars:
                 if isinstance(task_module_include_vars, dict):
-                    check_style_include_vars = task_module_include_vars.get('file', False) or task_module_include_vars.get('dir', task_module_include_vars)
+                    check_style_include_vars = task_module_include_vars.get(
+                        'file', False) or task_module_include_vars.get('dir', task_module_include_vars)
                 else:
                     check_style_include_vars = task_module_include_vars
-                sanitized_include_vars_name = sanitize_for_mermaid_id(f"{check_style_include_vars}{i}")
-                sanitized_include_vars_title = sanitize_for_title(check_style_include_vars)
+                sanitized_include_vars_name = sanitize_for_mermaid_id(
+                    f"{check_style_include_vars}{i}")
+                sanitized_include_vars_title = sanitize_for_title(
+                    check_style_include_vars)
                 mermaid_data += f'\n  {last_node}-->|Include vars| {sanitized_include_vars_name}[{sanitized_task_title}<br>include_vars: {sanitized_include_vars_title}]:::includeVars'
                 last_node = sanitized_include_vars_name
 
@@ -149,7 +174,7 @@ def process_tasks(tasks, last_node, mermaid_data, parent_node=None, level=0, in_
     if parent_node and not in_rescue_block and not has_rescue:
         end_label = "End of Block"
         mermaid_data += f'\n  {last_node}-.->|{end_label}| {parent_node}'
-                
+
     return last_node, mermaid_data
 
 

--- a/docsible/utils/special_tasks_keys.py
+++ b/docsible/utils/special_tasks_keys.py
@@ -1,5 +1,6 @@
 """Module with function for manage block and rescue code"""
 
+
 def escape_pipes(text):
     """Function to escape pipes in string or list"""
     if isinstance(text, str):
@@ -29,7 +30,7 @@ def process_special_task_keys(task, task_type='task'):
         'prompt', 'wait_for', 'wait_for_connection', 'meta', 'fact_path',
         'host_vars', 'group_vars', 'role'
     }
-    
+
     for block_type in ('block', 'rescue', 'always'):
         if block_type in task:
             task_name = task.get('name', f'Unnamed_{block_type}')
@@ -42,20 +43,22 @@ def process_special_task_keys(task, task_type='task'):
                 'when': task_when
             })
             for sub_task in task[block_type]:
-                processed_tasks = process_special_task_keys(sub_task, block_type)
+                processed_tasks = process_special_task_keys(
+                    sub_task, block_type)
                 tasks.extend(processed_tasks)
             return tasks  # Exit after processing block, rescue, or always
 
     # Handle regular tasks
     task_name = task.get('name', 'Unnamed')
     task_when = escape_pipes(task.get('when', None))
-    
+
     # Determine module name based on known task indicators or default to 'unknown'
     task_module = 'unknown'  # Default module if not found
     if 'action' in task:
         action = task['action']
         if isinstance(action, dict):
-            task_module = list(action.keys())[0]  # Module name from action dict
+            # Module name from action dict
+            task_module = list(action.keys())[0]
         else:
             task_module = action  # Module name as action string
     else:

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -2,12 +2,15 @@
 import os
 import yaml
 
+
 def vault_constructor(loader, node):
     # Handle '!vault' tag to prevent constructor issues
     return "ENCRYPTED_WITH_ANSIBLE_VAULT"
 
+
 # Register the custom constructor with the '!vault' tag.
 yaml.SafeLoader.add_constructor('!vault', vault_constructor)
+
 
 def load_yaml_generic(filepath):
     """Function to load YAML in a standard way"""
@@ -19,13 +22,14 @@ def load_yaml_generic(filepath):
         print(f"Error loading {filepath}: {e}")
         return None
 
+
 def load_yaml_file_custom(filepath):
     """
     Function to load YAML, evaluate comments and avoid reporting vault values.
-    
+
     Args:
         filepath (str): The path to the YAML file.
-        
+
     Returns:
         dict: A dictionary with keys representing YAML keys and values containing the value,
               title, required, choices, description, line number, and type of each key.
@@ -59,29 +63,38 @@ def load_yaml_file_custom(filepath):
                     comments.reverse()
 
                     # Initialize with default None values
-                    comment_dict = {'title': "n/a", 'required': "n/a", 'choices': "n/a", 'description': "n/a"}
+                    comment_dict = {'title': "n/a", 'required': "n/a",
+                                    'choices': "n/a", 'description': "n/a"}
                     for comment in comments:
                         comment_lower = comment.lower()
                         if 'title:' in comment_lower:
-                            title_index = comment_lower.find('title:') + 6  # Start after 'title:'
+                            title_index = comment_lower.find(
+                                'title:') + 6  # Start after 'title:'
                             if title_index > -1:
                                 # Trim any whitespace after the colon before capturing the value
-                                comment_dict['title'] = comment[title_index:].lstrip()
+                                comment_dict['title'] = comment[title_index:].lstrip(
+                                )
                         if 'required:' in comment_lower:
-                            required_index = comment_lower.find('required:') + 9  # Start after 'required:'
+                            required_index = comment_lower.find(
+                                'required:') + 9  # Start after 'required:'
                             if required_index > -1:
                                 # Trim any whitespace after the colon before capturing the value
-                                comment_dict['required'] = comment[required_index:].lstrip()
+                                comment_dict['required'] = comment[required_index:].lstrip(
+                                )
                         if 'choices:' in comment_lower:
-                            choices_index = comment_lower.find('choices:') + 8  # Start after 'choices:'
+                            choices_index = comment_lower.find(
+                                'choices:') + 8  # Start after 'choices:'
                             if choices_index > -1:
                                 # Trim any whitespace after the colon before capturing the value
-                                comment_dict['choices'] = comment[choices_index:].lstrip()
+                                comment_dict['choices'] = comment[choices_index:].lstrip(
+                                )
                         if 'description:' in comment_lower:
-                            description_index = comment_lower.find('description:') + 12  # Start after 'description:'
+                            description_index = comment_lower.find(
+                                'description:') + 12  # Start after 'description:'
                             if description_index > -1:
                                 # Trim any whitespace after the colon before capturing the value
-                                comment_dict['description'] = comment[description_index:].lstrip()
+                                comment_dict['description'] = comment[description_index:].lstrip(
+                                )
                         if 'description-lines:' in comment_lower:
                             description_lines = []
                             start_collecting = False  # Flag to start collecting lines
@@ -101,13 +114,16 @@ def load_yaml_file_custom(filepath):
 
                                 if start_collecting:
                                     if line_content.startswith("#"):
-                                        description_lines.append(f'{line_content[1:].strip()}<br>')  # Collect the line content
+                                        # Collect the line content
+                                        description_lines.append(
+                                            f'{line_content[1:].strip()}<br>')
                                     else:
                                         break  # Stop if a non-comment line is encountered
 
                             # Join all collected lines into a single description string
                             if description_lines:
-                                comment_dict['description'] = "\n".join(description_lines)
+                                comment_dict['description'] = "\n".join(
+                                    description_lines)
 
                     # Handle multiline values
                     if is_multiline_value(line):
@@ -136,16 +152,20 @@ def load_yaml_file_custom(filepath):
         print(f"Error loading {filepath}: {e}")
         return None
 
+
 def load_yaml_files_from_dir_custom(dir_path):
     """Function to load all YAML files from a given directory and include file names"""
     collected_data = []
     if os.path.exists(dir_path) and os.path.isdir(dir_path):
         for yaml_file in os.listdir(dir_path):
             if yaml_file.endswith(".yml") or yaml_file.endswith(".yaml"):
-                file_data = load_yaml_file_custom(os.path.join(dir_path, yaml_file))
+                file_data = load_yaml_file_custom(
+                    os.path.join(dir_path, yaml_file))
                 if file_data:
-                    collected_data.append({'file': yaml_file, 'data': file_data})
+                    collected_data.append(
+                        {'file': yaml_file, 'data': file_data})
     return collected_data
+
 
 def get_task_comments(filepath):
     with open(filepath, 'r', encoding='utf-8') as f:
@@ -164,7 +184,8 @@ def get_task_comments(filepath):
 
         # If a new task starts with "- name:", capture the accumulated comments and task name
         elif stripped_line.startswith("- name:"):
-            task_name = stripped_line.replace("- name:", "").split("#")[0].strip().replace("|", "¦")
+            task_name = stripped_line.replace(
+                "- name:", "").split("#")[0].strip().replace("|", "¦")
             task_comments.append({
                 "task_name": task_name,
                 "task_comments": comment_line.strip()  # Trim excess whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.7.12"
+version = "0.7.13"
 description = "Document generator for ansible role/collection"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 repository = "https://github.com/docsible/docsible"

--- a/scripts/change_version.py
+++ b/scripts/change_version.py
@@ -22,17 +22,18 @@ import argparse
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+
 def change_version(version_str: str, bump: bool = True) -> str:
     """
     Change the patch version number.
-    
+
     Args:
         version_str (str): A semantic version string in the format 'major.minor.patch'
         bump (bool): If True, increment the patch version; if False, decrement it.
-    
+
     Returns:
         str: The updated version string.
-    
+
     Raises:
         ValueError: If the version format is invalid.
     """
@@ -50,10 +51,11 @@ def change_version(version_str: str, bump: bool = True) -> str:
         patch -= 1
     return f"{major}.{minor}.{patch}"
 
+
 def update_file(file_path: str, pattern: str, replacement_format: str, new_version: str):
     """
     Updates a file by replacing the version string with the new version.
-    
+
     Args:
         file_path (str): The path to the file.
         pattern (str): A regex pattern to find the version string.
@@ -68,10 +70,12 @@ def update_file(file_path: str, pattern: str, replacement_format: str, new_versi
     if not re.search(pattern, content):
         logging.error(f"Version string not found in {file_path}")
         sys.exit(1)
-    new_content = re.sub(pattern, replacement_format.format(new_version), content)
+    new_content = re.sub(
+        pattern, replacement_format.format(new_version), content)
     with open(file_path, "w") as f:
         f.write(new_content)
     logging.info(f"Updated {file_path}")
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -123,9 +127,11 @@ def main():
     # Update all files with the new version.
     update_file(cli_file, cli_pattern, cli_replacement, new_version)
     update_file(setup_file, setup_pattern, setup_replacement, new_version)
-    update_file(pyproject_file, pyproject_pattern, pyproject_replacement, new_version)
-    
+    update_file(pyproject_file, pyproject_pattern,
+                pyproject_replacement, new_version)
+
     logging.info(f"Version update complete. New version: {new_version}")
+
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.7.12',
+    version='0.7.13',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
This PR enhances **Docsible's ability to render correct file links in the generated README** files by properly handling custom repository URLs.

Also executed pep8 clean

### Why?
When README files are embedded or browsed outside of their Git context (e.g. on external documentation sites), relative links break. This change ensures that:
- Each variable or task reference is rendered as a fully-qualified URL pointing to the file and line on the respective Git hosting provider (GitHub, GitLab, Gitea, etc.)
- It works automatically if the project is under Git and has a valid remote
- It supports manual override via CLI: `--repository-url`, `--repo-type`, `--repo-branch`

### What's included?
- New `get_repo_info(path)` logic using Git subprocess to extract:
  - Cleaned remote URL (stripped of `.git` and trailing slashes)
  - Current branch name
- Optional CLI arguments:
  - `--repository-url` (`-ru`)
  - `--repo-type` (`-rt`)  
  - `--repo-branch` (`-rb`)
- Automatic fallback to Git inspection if the user doesn't specify values
- Default handling for unknown repo types
- Updated Jinja `render_repo_link()` macro to generate correct links for:
  - GitHub
  - GitLab
  - Gitea
  - Generic FQDN fallback

---

## ✅ How Has This Been Tested?

- [x] Ran `python -m docsible.cli` on roles with and without `.git` context
- [x] Confirmed correct rendering for:
  - GitHub URLs with `.git` suffix
  - GitLab and Gitea links using appropriate path format
  - Local dev Git instances like `https://dev.local`
- [x] Verified fallback logic when Git is missing or fails
- [x] Inspected output Markdown in external viewers (VSCode preview, GitHub, Gitea)

---

## 🧪 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added comments where logic is not obvious
- [ ] I have made corresponding changes to the documentation and Jinja templates
- [x] My changes generate no new warnings
- [x] I have verified proper CLI fallback behavior and link correctness
- [x] All updated templates were rendered and visually validated
