### PR TITLE
allow user to chose if auto detect --repository-url if not fallback t…

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -112,17 +112,17 @@ def document_collection_roles(collection_path, playbook, graph, no_backup, no_do
     """
     Document all roles in a collection, extracting metadata from galaxy.yml or galaxy.yaml.
     """
-    try:
-        git_info = get_repo_info(collection_path) or {}
-    except Exception as e:
-        print(f"[WARN] Could not get Git info: {e}")
-        git_info = {}
-    repository_url = repository_url or (
-        git_info.get("repository") if git_info else None)
-    repo_branch = repo_branch or (
-        git_info.get("branch") if git_info else "main")
-    repo_type = repo_type or (
-        git_info.get("repository_type") if git_info else None)
+    if repository_url == "detect":
+        try:
+            git_info = get_repo_info(collection_path) or {}
+        except Exception as e:
+            print(f"[WARN] Could not get Git info: {e}")
+            git_info = {}
+        repository_url = git_info.get("repository") if git_info else None
+        repo_branch = repo_branch or (
+            git_info.get("branch") if git_info else "main")
+        repo_type = repo_type or (
+            git_info.get("repository_type") if git_info else None)
 
     for root, dirs, files in os.walk(collection_path):
         galaxy_file = next(
@@ -246,17 +246,17 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
     vars_data = load_yaml_files_from_dir_custom(
         os.path.join(role_path, "vars")) or []
 
-    try:
-        git_info = get_repo_info(role_path) or {}
-    except Exception as e:
-        print(f"[WARN] Could not get Git info: {e}")
-        git_info = {}
-    repository_url = repository_url or (
-        git_info.get("repository") if git_info else None)
-    repo_branch = repo_branch or (
-        git_info.get("branch") if git_info else "main")
-    repo_type = repo_type or (
-        git_info.get("repository_type") if git_info else None)
+    if repository_url == "detect":
+        try:
+            git_info = get_repo_info(role_path) or {}
+        except Exception as e:
+            print(f"[WARN] Could not get Git info: {e}")
+            git_info = {}
+        repository_url = git_info.get("repository") if git_info else None
+        repo_branch = repo_branch or (
+            git_info.get("branch") if git_info else "main")
+        repo_type = repo_type or (
+            git_info.get("repository_type") if git_info else None)
 
     role_info = {
         "name": role_name,


### PR DESCRIPTION
Auto detect repository url: `docsible --role . --repository-url detect`

If `--repository-url detect` is not used, user have to pass other arguments to config paths for url.

Example: `docsible --role . --repository-url https://github.com/docsible/thermo-core --repo-type github --repo-branch main`

If `--repository-url` is not passed as argument, links will be handled without href repo url, direct path with be served.