### PR TITLE
make role template deterministic

### DIFF
--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -134,7 +134,7 @@ Description: Not available.
 ### Defaults
 
 **These are static variables with lower priority**
-{%- for defaultfile in role.defaults %}
+{%- for defaultfile in role.defaults|sort(attribute='file') %}
 
 #### File: defaults/{{ defaultfile.file }}
 {# Cycle used for deciding to set Title and Required Column #}
@@ -152,7 +152,7 @@ Description: Not available.
 {%- endfor %}
 {%- endfor %}
 
-{%- for defaultfile in role.defaults -%}
+{%- for defaultfile in role.defaults|sort(attribute='file') -%}
 {%- set ns = namespace(has_descriptions = false) -%}
 {%- for key, details in defaultfile.data.items() -%}
     {%- if details.description != "n/a" -%}{%- set ns.has_descriptions = true -%}{% endif -%}
@@ -179,7 +179,7 @@ Description: Not available.
 ### Vars
 
 **These are variables with higher priority**
-{%- for varsfile in role.vars %}
+{%- for varsfile in role.vars|sort(attribute='file') %}
 #### File: vars/{{ varsfile.file }}
 {# Cycle used for deciding to set Title and Required Column #}
 {% set ns = namespace(details_required = false, details_title = false, details_choices = false) %}
@@ -196,7 +196,7 @@ Description: Not available.
 {%- endfor %}
 {%- endfor %}
 
-{%- for varsfile in role.vars -%}
+{%- for varsfile in role.vars|sort(attribute='file') -%}
 {% set ns = namespace(has_descriptions = false) -%}
 {%- for key, details in varsfile.data.items() -%}
     {%- if details.description != "n/a" -%}{%- set ns.has_descriptions = true -%}{%- endif %}
@@ -221,7 +221,7 @@ Description: Not available.
 
 ### Tasks
 
-{% for taskfile in role.tasks %}
+{% for taskfile in role.tasks|sort(attribute='file') %}
 #### File: tasks/{{ taskfile.file }}
 {% set ns = namespace (comments_required = false) %}{% for comment in taskfile['comments'] %}{% if comment != "" %}{% set ns.comments_required = true %}{% endif %}{% endfor %}
 | Name | Module | Has Conditions |{% if ns.comments_required %} Comments |{% endif %}


### PR DESCRIPTION
due to #71 i am assuming that the [template](https://github.com/docsible/templates) is not yet used. Or otherwise the migration is missing. so i redo #59. 

# Description

With multiple files (not just `main.yaml`) it can be non-deterministic as well.

Fixes deterministic behavior for roles as well.

# How Has This Been Tested?

verified with [gitlab-runner](https://github.com/riemers/ansible-gitlab-runner)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
