### PR TITLE
Add links with line numbers for tasks

### DIFF
--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -227,7 +227,11 @@ Description: Not available.
 | Name | Module | Has Conditions |{% if ns.comments_required %} Comments |{% endif %}
 | ---- | ------ | --------- |{% if ns.comments_required %}  -------- |{% endif %}
 {%- for task in taskfile.tasks %}
-| {{ task.name.replace("|", "¦") }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |{% if ns.comments_required %} {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |{% endif %}
+{%- if taskfile['lines'] | length > 0 %}
+| [{{ task.name.replace("|", "¦") }}]({{ render_repo_link(role.repository, role.name, 'tasks/' ~ taskfile.file, taskfile['lines'][task.name], role.repository_type, role.repository_branch) }}) | {{ task.module }} | {{ 'True' if task.when else 'False' }} |{% if ns.tags_required %} {{ taskfile['mermaid'] | selectattr('name', 'equalto', task.name) | map(attribute='tags') | list | first | join(',') }} |{% endif %}{% if ns.comments_required %} {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |{% endif %}
+{%- else %}
+| {{ task.name.replace("|", "¦") }} | {{ task.module }} | {{ 'True' if task.when else 'False' }} |{% if ns.tags_required %} {{ taskfile['mermaid'] | selectattr('name', 'equalto', task.name) | map(attribute='tags') | list | first | join(',') }} |{% endif %}{% if ns.comments_required %} {{ taskfile['comments'] | selectattr('task_name', 'equalto', task.name) | map(attribute='task_comments') | join }} |{% endif %}
+{%- endif %}
 {%- endfor %}
 {% endfor %}
 

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -200,3 +200,18 @@ def get_task_comments(filepath):
             comment_line = ""
 
     return task_comments
+
+def get_task_line_numbers(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    tasks_lines = {}
+    for idx, line in enumerate(lines):
+        stripped_line = line.strip()
+
+        if stripped_line.startswith("- name:"):
+            task_name = stripped_line.replace(
+                "- name:", "").split("#")[0].strip().replace("|", "¦").replace("'", "").replace('"', "")
+            tasks_lines[task_name] = idx + 1
+
+    return tasks_lines


### PR DESCRIPTION
The goal was to have links from docs directly into tasks as it was already possible for vars.
Therefor the argument --task-line was added to be able to use the new function.
The default template was adjusted so the new function is usable out of the box.

