### PR TITLE
Fix generation of collection documentation

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -193,7 +193,7 @@ def doc_the_role(role, collection, playbook, graph, no_backup, no_docsible, comm
         if not os.path.exists(collection_path) or not os.path.isdir(collection_path):
             print(f"Folder {collection_path} does not exist.")
             return
-        document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments, task_line,
+        document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments,
                                   md_collection_template, md_role_template, append, output, repository_url, repo_type, repo_branch)
     elif role:
         role_path = os.path.abspath(role)


### PR DESCRIPTION
## Bug that should be fixed by this PR

Unable to generate documentation of a collection with the CLI. It produces a TypeError. 

## Environment

- **Docsible Version**: docsible, version 0.7.20
- **Python Version**: 3.13
- **Operating System**: macOS
- **CLI or Script**: CLI

## To Reproduce

1. Run the following command `docsible -c <collection_path>`

## Expected Behavior

The documentation should be generated. 

## Actual Behavior

TypeError: document_collection_roles() takes 13 positional arguments but 14 were given

## Logs

Traceback (most recent call last):
  File "docsible", line 10, in <module>
    sys.exit(doc_the_role())
             ~~~~~~~~~~~~^^
  File "docsible/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "docsible/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "docsible/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "docsible/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "docsible/lib/python3.13/site-packages/docsible/cli.py", line 196, in doc_the_role
    document_collection_roles(collection_path, playbook, graph, no_backup, no_docsible, comments, task_line,
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                              md_collection_template, md_role_template, append, output, repository_url, repo_type, repo_branch)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: document_collection_roles() takes 13 positional arguments but 14 were given

## Additional Context

It seems to be a regression of commit 056ac4c5de (7th of May 2025). In function doc_the_role, the call of document_collection_roles uses task_line while the definition of this function doesn't have it. 

Be aware that I have done no test and not analyzed the full project.
