### PR TITLE
Issue 84/handle indention indicators

### DIFF
--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -17,7 +17,7 @@ timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
 
 
 def get_version():
-    return "0.7.21"
+    return "0.7.22"
 
 
 def manage_docsible_file_keys(docsible_path):

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -27,7 +27,7 @@ def load_yaml_generic(filepath):
 def get_multiline_indicator(line):
     """
     Detect and map YAML multiline scalar indicators to a descriptive name.
-    Handles all combinations of |, >, +, -, and 1–9 indent levels.
+    Handles all combinations of |, >, +, -, and 1-9 indent levels.
     Returns: e.g., 'literal', 'folded_keep_indent_2', or 'invalid_...'
     """
     match = re.match(r'^\s*\w[\w\-\.]*\s*:\s*([>|][^\s#]*)', line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docsible"
-version = "0.7.21"
+version = "0.7.22"
 description = "Document generator for ansible role/collection"
 authors = ["Lucian BLETAN <neuraluc@gmail.com>"]
 repository = "https://github.com/docsible/docsible"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='docsible',
-    version='0.7.21',
+    version='0.7.22',
     packages=find_packages(),
     include_package_data=True,
     author='Lucian BLETAN',


### PR DESCRIPTION
# Description

This change improves YAML parsing within the `load_yaml_file_custom()` function by introducing a more robust and dynamic detection of multiline scalar indicators (e.g., `|`, `>`, `|+2`). It maps valid YAML block scalar indicators to human-readable descriptive names such as `literal_keep_indent_2` and correctly handles edge cases (e.g., reordered indicators like `|2+`, or invalid ones like `|+10` or `>-99`).

### Motivation:

Previously, the detection of multiline scalars was incomplete. Basic forms such as `|` or `|+` were not being detected correctly, and invalid indicators were not flagged. This enhancement ensures more accurate introspection, better documentation generation, and cleaner error reporting.

Fixes #83

# How Has This Been Tested?

The following scenarios were verified:

* Parsing valid multiline scalar forms: `|`, `>`, `|+`, `|-`, `|2`, `|+2`, `|2+`, `>+`, `>-`, `>2`, `>2+`.
* Detection of invalid forms such as `|+10`, `|-99`, and `|++` now properly returns `invalid_...`.
* Integration tested by loading a full `defaults/main.yml` file and inspecting the parsed `multiline_indicator` and `value` fields in the output JSON.
* Confirmed that output matches expected values in rendered tables and CLI summary.
