### PR TITLE
feat: Add markdown to HTML link conversion in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Docsible is a command-line interface (CLI) written in Python that automates the 
 - Includes meta-data like author and license from `meta/main.[yml/yaml]`
 - Generates a well-structured table for default and role-specific variables
 - Support for encrypted Ansible Vault variables
+- Automatically converts markdown links (e.g., `[text](url)`) in variable descriptions (from `# description:` and `# description-lines:` comments in YAML files) to HTML `<a>` tags in the generated documentation.
 
 ## Installation
 

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -134,6 +134,8 @@ def load_yaml_file_custom(filepath):
                     meta['choices'] = comment[8:].strip()
                 elif lc.startswith('description:'):
                     meta['description'] = comment[12:].strip()
+                    if meta['description']:
+                        meta['description'] = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', meta['description'])
                 elif lc.startswith('description-lines:'):
                     description_lines = []
                     start_collecting = False  # Flag to start collecting lines
@@ -154,8 +156,9 @@ def load_yaml_file_custom(filepath):
                         if start_collecting:
                             if line_content.startswith("#"):
                                 # Collect the line content
-                                description_lines.append(
-                                    f'{line_content[1:].strip()}<br>')
+                                line_to_add = line_content[1:].strip()
+                                line_to_add = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', line_to_add)
+                                description_lines.append(f'{line_to_add}<br>')
                             else:
                                 break  # Stop if a non-comment line is encountered
                     


### PR DESCRIPTION
This commit introduces the capability for docsible to automatically convert markdown-style links (e.g., `[text](url)`) found in Ansible variable descriptions into HTML `<a>` tags. This applies to descriptions provided via `# description:` and `# description-lines:` comments in YAML files.

This ensures that links embedded in descriptions are rendered correctly as clickable hyperlinks in the final documentation.

This includes the feature implementation and updated documentation in README.md. Unit tests have been excluded from this commit as per your request.