### PR TITLE
Added support for playbooks with lists of hosts in mermaid.py

### DIFF
--- a/docsible/utils/mermaid.py
+++ b/docsible/utils/mermaid.py
@@ -184,8 +184,15 @@ def generate_mermaid_playbook(playbook):
         hosts = play.get("hosts", "UndefinedHost")
         tasks = play.get("tasks", [])
         roles = play.get("roles", [])
-        hosts = re.sub(r"{{\s*(\w+)\s*}}", r"\1", hosts)
-        sanitized_hosts = sanitize_for_mermaid_id(hosts)
+        if not isinstance(hosts, list):
+            hosts = [hosts]
+        sanitized_hosts = []
+        for host in hosts:
+            host = re.sub(r"{{\s*(\w+)\s*}}", r"\1", host)
+            host = sanitize_for_mermaid_id(host)
+            sanitized_hosts.append(host)
+        sanitized_hosts = ", ".join(sanitized_hosts)
+        sanitized_hosts = "hosts[" + sanitized_hosts + "]"
         last_node = sanitized_hosts
         if roles:
             for i, role in enumerate(roles):


### PR DESCRIPTION
# Description

Adds support for playbooks with lists of hosts in mermaid.py. Currently, `generate_mermaid_playbook(playbook)` expects a single host, and fails on line 187 if a list is given. This branch builds a comma separated list of hosts for the starting node of the playbook graph.

Fixes # 101

# How Has This Been Tested?

I tested with the thermo-core example repository. When I add a list of hosts it generates the following graph:
```mermaid
flowchart TD
  hosts[localhost, test_host, test_host_2]-->|Role| thermo_core[thermo core]
```
When I run with a single host it generates the following graph:
```mermaid
flowchart TD
  hosts[localhost]-->|Role| thermo_core[thermo core]
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
