### PR TITLE
Enforce sort order of files

### DIFF
--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -256,7 +256,7 @@ Description: Not available.
 {% if mermaid_code_per_file -%}
 ## Task Flow Graphs
 
-{% for task_file, mermaid_code in mermaid_code_per_file.items() %}
+{% for task_file, mermaid_code in mermaid_code_per_file | dictsort %}
 
 ### Graph for {{ task_file }}
 


### PR DESCRIPTION
# Description

I noticed a discrepency between when I ran docsible on OSX and when I ran it on linux - the order of the graphs would change.

I haven't fully dug into the reason, but I assume it has to do with how the OS discovers the files. Notably, the order was stable on OSX and Linux individually - which made me think it was a difference between the OSes.

This fixes the problem by applying a dictsort to the dict, which alphabetically (and case insensitive) sorts by key.

# How Has This Been Tested?

I am using the template locally with `--md-template`. I've run the same code on OSX and Linux (Debian 12).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
