### PR TITLE
add support for python <=3.9 and update template handling

### DIFF
--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -70,7 +70,14 @@ Description: Not available.
   {{ indent }}  - **Required**: {{ details.required | default('false') }}
   {{ indent }}  - **Type**: {{ details.type }}
   {{ indent }}  - **Default**: {{ details.default | default('none') }}
+  {% if details.description is iterable and (details.description is not string and details.description is not mapping) -%}
+  {{ indent }}  - **Description**: 
+  {% for details_desc in details.description %}
+      {{ indent }} - {{ details_desc }}
+  {% endfor %}
+  {% else %}
   {{ indent }}  - **Description**: {{ details.description | default('No description provided') }}
+  {% endif %}
   {% if details.choices is defined %}
     {{ indent }}  - **Choices**:
     {% for choice in details.choices %}
@@ -100,8 +107,19 @@ Description: Not available.
 <summary><b>🧩 Argument Specifications in meta/argument_specs</b></summary>
 {% for section, specs in role.argument_specs.argument_specs.items() %}
 #### Key: {{ section }}
+{% if specs.description is iterable and (specs.description is not string and specs.description is not mapping) %}
+**Description**: 
+{% for desc in specs.description %}
+  - {{ desc }}
+{% endfor %}
+{% else %}
 **Description**: {{ specs.description or specs.short_description or 'No description provided' }}
+{% endif %}
+
+{% if specs.options is defined %}
+**Options**:
 {{ render_arguments_list(specs.options) }}
+{% endif %}
 {% endfor %}
 </details>
 {% else %}
@@ -415,7 +433,14 @@ Description: Not available.
   {{ indent }}  - **Required**: {{ details.required | default('false') }}
   {{ indent }}  - **Type**: {{ details.type }}
   {{ indent }}  - **Default**: {{ details.default | default('none') }}
+  {% if details.description is iterable and (details.description is not string and details.description is not mapping) -%}
+  {{ indent }}  - **Description**: 
+  {% for details_desc in details.description %}
+      {{ indent }} - {{ details_desc }}
+  {% endfor %}
+  {% else %}
   {{ indent }}  - **Description**: {{ details.description | default('No description provided') }}
+  {% endif %}
   {% if details.choices is defined %}
     {{ indent }}  - **Choices**:
     {% for choice in details.choices %}

--- a/docsible/utils/git.py
+++ b/docsible/utils/git.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
# Description

The `or` operand in type hints is not supported in Python <=3.9. Adding the `from __future__ import annotations` allows this funcitonality to be supported in older Python releases.

This PR also includes changes to support the usage of "Description" in a multi-line format as is permitted by Ansible documentation standards. 

Fixes #106 
Fixed #107 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Attempt to generate documentation for a role: `docsible --role roles/updates -ru detect -nob --graph`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
