### PR TITLE
feat(templates): add URL support for role and collection templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Options:
   -nob, --no-backup               Do not backup the readme before remove.
   -nod, --no-docsible             Do not generate .docsible file and do not include it in README.md.
   -com, --comments                Read comments from tasks files
-  -ctpl, --md-collection-template TEXT Path to the collection markdown template file.
+  -ctpl, --md-collection-template TEXT Path or URL to the collection markdown template file.
   -rtpl, -tpl, --md-role-template, --md-template TEXT
-                                  Path to the role markdown template file.
+                                  Path or URL to the role markdown template file.
   -a, --append                    Append to the existing README.md instead of
                                   replacing it.
   -o, --output TEXT               Output readme file name.
@@ -93,8 +93,8 @@ Options:
 - `--no-backup`: Ignore existent README.md and remove before generate a new one. (Optional).
 - `--no-docsible`: Do not generate `.docsible` metadata file and exclude it from the README.md. (Optional).
 - `--comments`: Read comments from tasks files. (Optional).
-- `--md-template`: Specifies the path to the markdown template file (Optional). (Works only with roles)
-- `--md-collection-template`: Specifies the path to the markdown template file for documenting collections. (Optional).
+- `--md-template`: Specifies the path or URL to the markdown template file (Optional). (Works only with roles)
+- `--md-collection-template`: Specifies the path or URL to the markdown template file for documenting collections. (Optional).
 - `--append`: Append existing readme.md if needed.
 - `--output`: Output readme file name. Defaults to `README.md`.
 - `--repository-url`: Repository base URL (used for standalone roles). Use `detect` to auto-detect using Git, or provide a full URL.
@@ -122,6 +122,7 @@ Docsible works with Python 3.x and requires the following libraries:
 - Click
 - Jinja2
 - PyYAML
+- requests
 
 ## TODO
 - Clean the code

--- a/docsible/cli.py
+++ b/docsible/cli.py
@@ -343,7 +343,6 @@ def document_role(role_path, playbook_content, generate_graph, no_backup, no_doc
         mermaid_code_per_file = generate_mermaid_role_tasks_per_file(
             role_info["tasks"])
 
-
     # Render the static template
     if md_role_template:
         if is_url(md_role_template):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 click = "^8.1.7"
 PyYAML = "^6.0.1"
 Jinja2 = "^3.1.2"
+requests = "^2.32.5"
 
 
 [build-system]


### PR DESCRIPTION
# Description

Allow loading Jinja2 templates from HTTP/HTTPS URLs in addition to local file paths. This enables keeping a central template configuration that can be reused across multiple projects or locations.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
