### PR TITLE
fix(#130): Render list of dicts nested options correctly

### DIFF
--- a/docsible/markdown_template.py
+++ b/docsible/markdown_template.py
@@ -95,14 +95,8 @@ Description: {{ role.meta.galaxy_info.description or 'Not available.' }}
       {{ indent }}    - {{ alias }}
     {% endfor %}
   {% endif %}
-  {% if details.type == 'dict' and details.options %}
+  {% if (details.type == 'dict' and details.options) or (details.type == 'list' and details.elements == 'dict' and details.options) %}
     {{ render_arguments_list(details.options, level + 1) }}
-  {% elif details.type == 'list' and details.elements == 'dict' %}
-    {% for elem in details.default %}
-      {% if elem is mapping %}
-        {{ render_arguments_list(elem, level + 1) }}
-      {% endif %}
-    {% endfor %}
   {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/tests/fixtures/minimal_arg_specs.yml
+++ b/tests/fixtures/minimal_arg_specs.yml
@@ -1,0 +1,17 @@
+---
+argument_specs:
+  main:
+    options:
+      my_list:
+        type: list
+        elements: dict
+        default: []
+        description: "A list of dicts."
+        options:
+          name:
+            type: str
+            required: true
+            description: "Name of the item."
+          value:
+            type: int
+            description: "Value of the item."

--- a/tests/fixtures/minimal_arg_specs_with_default.yml
+++ b/tests/fixtures/minimal_arg_specs_with_default.yml
@@ -1,0 +1,18 @@
+---
+argument_specs:
+  main:
+    options:
+      my_list:
+        type: list
+        elements: dict
+        default:
+          - name: "Example"
+        description: "A list of dicts."
+        options:
+          name:
+            type: str
+            required: true
+            description: "Name of the item."
+          value:
+            type: int
+            description: "Value of the item."

--- a/tests/test_nested_list_of_dicts.py
+++ b/tests/test_nested_list_of_dicts.py
@@ -1,0 +1,56 @@
+from docsible.markdown_template import static_template
+from jinja2 import Environment, BaseLoader
+import yaml
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+def load_fixture(name):
+  with open(FIXTURES / name) as f:
+      return yaml.safe_load(f)
+
+def render_template(argument_specs):
+
+  env = Environment(loader=BaseLoader)
+  template = env.from_string(static_template)
+
+  role_info = {
+      "name": "test_role",
+      "argument_specs": argument_specs,
+      "defaults": [],
+      "vars": [],
+      "tasks": [],
+      "meta": {},
+      "playbook": {"content": None, "graph": None},
+      "docsible": None,
+      "belongs_to_collection": False,
+      "repository": None,
+      "repository_type": None,
+      "repository_branch": None,
+  }
+
+  return template.render(
+      role=role_info,
+      mermaid_code_per_file={},
+  )
+
+
+def test_nested_list_of_dicts_without_default():
+  rendered = render_template(
+      load_fixture("minimal_arg_specs.yml")
+  )
+  assert "- **my_list**" in rendered
+  assert "- **name**" in rendered
+  assert rendered.index("my_list") < rendered.index("name")
+
+def test_nested_list_of_dicts_with_default():
+  rendered = render_template(
+      load_fixture("minimal_arg_specs_with_default.yml")
+  )
+  print(rendered)
+  assert "- **my_list**" in rendered
+  assert "- **name**" in rendered
+  assert "- **value**" in rendered
+  assert "- **Required**: True" in rendered
+  assert "Name of the item." in rendered
+  assert "Value of the item." in rendered


### PR DESCRIPTION
# Description

We now render all the options in a list of dicts regardless of the default value, and the various metadata is now rendered correctly.

Fixes #130 

# How Has This Been Tested?

- [tests/nested-list-of-dicts.py](https://github.com/docsible/docsible/compare/main...Adam-SCP:docsible:fix/list-dict-options?expand=1#diff-7a36772d4ee0ce7f1608e34940600c90491eb133cc6538a6b163560966ab0aa2)
  - [x] test_nested_list_of_dicts_without_default()
  - [x] test_nested_list_of_dicts_with_default()

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
