### PR TITLE
fix: gracefully handle !unsafe Ansible YAML tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Docsible is a command-line interface (CLI) written in Python that automates the 
 - Includes meta-data like author and license from `meta/main.[yml/yaml]`
 - Generates a well-structured table for default and role-specific variables
 - Support for encrypted Ansible Vault variables
+- Gracefully handles `!unsafe` Ansible YAML tag
 
 ## Installation
 

--- a/docsible/utils/yaml.py
+++ b/docsible/utils/yaml.py
@@ -9,8 +9,37 @@ def vault_constructor(loader, node):
     return "ENCRYPTED_WITH_ANSIBLE_VAULT"
 
 
-# Register the custom constructor with the '!vault' tag.
+def unsafe_constructor(loader, node):
+    """
+    Handle !unsafe tag by preserving it in documentation output.
+
+    Uses smart quoting: chooses quote wrapper (single or double) that minimizes
+    or eliminates the need for backslash escaping, producing cleaner docs.
+
+    Examples:
+        'He said "hello"'  -> !unsafe 'He said "hello"'  (no escaping needed)
+        "It's working"     -> !unsafe "It's working"     (no escaping needed)
+        'Mix "both" types' -> !unsafe "Mix \"both\" types" (escaping required)
+    """
+    value = loader.construct_scalar(node)
+    has_double_quotes = '"' in value
+    has_single_quotes = "'" in value
+
+    if has_double_quotes and has_single_quotes:
+        # Both quote types present: use double quotes and escape embedded doubles
+        escaped = value.replace('"', r'\"')
+        return f'!unsafe "{escaped}"'
+    elif has_double_quotes:
+        # Only double quotes: wrap in single quotes to avoid escaping
+        return f"!unsafe '{value}'"
+    else:
+        # Only single quotes or neither: wrap in double quotes
+        return f'!unsafe "{value}"'
+
+
+# Register the custom constructors for known Ansible tags.
 yaml.SafeLoader.add_constructor('!vault', vault_constructor)
+yaml.SafeLoader.add_constructor('!unsafe', unsafe_constructor)
 
 
 def load_yaml_generic(filepath):

--- a/tests/fixtures/unsafe_tag_fixture.yml
+++ b/tests/fixtures/unsafe_tag_fixture.yml
@@ -1,0 +1,22 @@
+# !vault Ansible tag
+vault_encrypted: !vault |
+  encrypted_content
+
+# Basic !unsafe tag handling
+basic_unsafe: !unsafe '{{ not_a_template }}'
+complex_unsafe: !unsafe "{{ timestamp }} - [{{ log_level }}] {{ message }}"
+
+# Smart quoting: embedded double quotes (should use single quote wrapper)
+double_quotes: !unsafe 'He said "hello" to everyone'
+
+# Smart quoting: embedded single quotes (should use double quote wrapper)
+single_quotes: !unsafe "It's working perfectly"
+
+# Smart quoting: both quote types (must escape double quotes with backslash)
+mixed_quotes: !unsafe "She said \"it's fine\" confidently"
+
+# Special characters: backslashes (should preserve as-is)
+backslashes: !unsafe 'C:\path\to\file'
+
+# Simple case: no quotes
+simple_value: !unsafe somevalue

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,8 +1,15 @@
+from pathlib import Path
+
 import pytest
 from docsible.utils.yaml import load_yaml_file_custom
 
+
+# Absolute path to fixture, works from both root and tests directory
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "type_fixture.yml"
+
+
 def test_type_detection():
-    result = load_yaml_file_custom("fixtures/type_fixture.yml")
+    result = load_yaml_file_custom(str(FIXTURE_PATH))
     # Type is overriden in the fixture to str
     assert result['test']['type'] == "str"
     # Type is overriden in the fixture to int

--- a/tests/test_yaml_tags.py
+++ b/tests/test_yaml_tags.py
@@ -1,0 +1,66 @@
+"""Tests for Ansible YAML tag handling (!unsafe, !vault, and unknown tags)."""
+
+from docsible.utils.yaml import load_yaml_file_custom
+
+
+FIXTURE_PATH = "fixtures/unsafe_tag_fixture.yml"
+
+
+def load_test_fixture():
+    """Load the test fixture file once for all tests."""
+    return load_yaml_file_custom(FIXTURE_PATH)
+
+
+def test_vault_tag_uses_placeholder():
+    """!vault tag should show a placeholder since encrypted content cannot be displayed."""
+    result = load_test_fixture()
+
+    assert result['vault_encrypted']['value'] == "ENCRYPTED_WITH_ANSIBLE_VAULT"
+
+
+def test_basic_unsafe_tag_preservation():
+    """!unsafe tag should be preserved in output to document non-templated values."""
+    result = load_test_fixture()
+
+    assert result['basic_unsafe']['value'] == '!unsafe "{{ not_a_template }}"'
+    assert result['complex_unsafe']['value'] == '!unsafe "{{ timestamp }} - [{{ log_level }}] {{ message }}"'
+
+
+def test_smart_quoting_with_double_quotes():
+    """Values with embedded double quotes should use single quote wrapper (no escaping)."""
+    result = load_test_fixture()
+
+    # Smart quoting: wraps in single quotes to avoid backslash escaping
+    assert result['double_quotes']['value'] == "!unsafe 'He said \"hello\" to everyone'"
+
+
+def test_smart_quoting_with_single_quotes():
+    """Values with embedded single quotes should use double quote wrapper (no escaping)."""
+    result = load_test_fixture()
+
+    # Smart quoting: wraps in double quotes to avoid backslash escaping
+    assert result['single_quotes']['value'] == '!unsafe "It\'s working perfectly"'
+
+
+def test_smart_quoting_with_mixed_quotes():
+    """Values with both quote types must escape double quotes with backslash."""
+    result = load_test_fixture()
+
+    # When both quote types present, use double quotes and escape only the doubles
+    # Use regular string: apostrophe needs no escaping, only double quotes do
+    assert result['mixed_quotes']['value'] == '!unsafe "She said \\"it\'s fine\\" confidently"'
+
+
+def test_backslashes_preserved_without_escaping():
+    """Backslashes in values should be preserved as-is, not double-escaped."""
+    result = load_test_fixture()
+
+    # Backslashes are preserved literally (not escaped)
+    assert result['backslashes']['value'] == r'!unsafe "C:\path\to\file"'
+
+
+def test_simple_values_wrapped_in_quotes():
+    """Simple unquoted values should be wrapped in double quotes."""
+    result = load_test_fixture()
+
+    assert result['simple_value']['value'] == '!unsafe "somevalue"'

--- a/tests/test_yaml_tags.py
+++ b/tests/test_yaml_tags.py
@@ -1,14 +1,17 @@
 """Tests for Ansible YAML tag handling (!unsafe, !vault, and unknown tags)."""
 
+from pathlib import Path
+
 from docsible.utils.yaml import load_yaml_file_custom
 
 
-FIXTURE_PATH = "fixtures/unsafe_tag_fixture.yml"
+# Absolute path to fixture, works from both root and tests directory
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "unsafe_tag_fixture.yml"
 
 
 def load_test_fixture():
     """Load the test fixture file once for all tests."""
-    return load_yaml_file_custom(FIXTURE_PATH)
+    return load_yaml_file_custom(str(FIXTURE_PATH))
 
 
 def test_vault_tag_uses_placeholder():


### PR DESCRIPTION
# Description

Gracefully handle !unsafe Ansible YAML tag. Fixes #133 

# How Has This Been Tested?

Tests have been implemented in the tests directory to cover the fix, see `test_yaml_tags.py`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
